### PR TITLE
Corrected filter location grid

### DIFF
--- a/draw_model.py
+++ b/draw_model.py
@@ -26,7 +26,7 @@ class DRAWModel(nn.Module):
 
         # Stores the generated image for each time step.
         self.cs = [0] * self.T
-        
+
         # To store appropriate values used for calculating the latent loss (KL-Divergence loss)
         self.logsigmas = [0] * self.T
         self.sigmas = [0] * self.T
@@ -126,7 +126,7 @@ class DRAWModel(nn.Module):
         # Equation 2.
         log_sigma = self.fc_sigma(h_enc)
         sigma = torch.exp(log_sigma)
-        
+
         z = mu + e * sigma
 
         return z, mu, log_sigma, sigma
@@ -148,8 +148,8 @@ class DRAWModel(nn.Module):
         return self.filterbank(gx, gy, sigma_2, delta, N), gamma
 
     def filterbank(self, gx, gy, sigma_2, delta, N, epsilon=1e-8):
-        grid_i = torch.arange(start=0.0, end=N, device=self.device, requires_grad=True,).view(1, -1)
-        
+        grid_i = torch.arange(start=1.0, end=N+1, device=self.device, requires_grad=True,).view(1, -1)
+
         # Equation 19.
         mu_x = gx + (grid_i - N / 2 - 0.5) * delta
         # Equation 20.
@@ -172,7 +172,7 @@ class DRAWModel(nn.Module):
         if self.channel == 3:
             Fx = Fx.view(Fx.size(0), 1, Fx.size(1), Fx.size(2))
             Fx = Fx.repeat(1, 3, 1, 1)
-            
+
             Fy = Fy.view(Fy.size(0), 1, Fy.size(1), Fy.size(2))
             Fy = Fy.repeat(1, 3, 1, 1)
 


### PR DESCRIPTION
This is a great implementation! One small note:

On line 151:
```
grid_i = torch.arange(start=0.0, end=N, device=self.device, requires_grad=True,).view(1, -1)
```

I believe you should set the `arange` to be from `1 -> N`, rather than from `0 -> (N-1)`:
```
grid_i = torch.arange(start=1.0, end=N+1, device=self.device, requires_grad=True,).view(1, -1)
```

Doing this will ensure that the filter locations are around the center, `gx` and `gy`. Here's a figure from the paper for reference:

![image](https://user-images.githubusercontent.com/25353789/90668752-64ad1500-e205-11ea-901c-e27df0e697af.png)

Currently the grid is shifted more towards the top-left by 1 filter.

Below are some diagrams showing the differences between the current grid and the correct grid:

The red dot is the center `gx` and `gy`. The green rectangle is the current grid layout/filter locations, and the red rectangle is the correct grid layout/filter locations, using the recommended code change mentioned above.

Example 1 (N=5):
Notice how the filter grid contains `gx` and `gy`, but isn't centered around it!

![image](https://user-images.githubusercontent.com/25353789/90665176-8ce64500-e200-11ea-823c-d6bec9522f59.png)

![image](https://user-images.githubusercontent.com/25353789/90665160-88219100-e200-11ea-8ffb-f6595beedff5.png)

Example 2 (N=2):
Notice how the filter locations don't even contain `gx` and `gy`! One of DRAW's optimal configurations for MNIST was using a `read_N` of 2

![image](https://user-images.githubusercontent.com/25353789/90668563-20217980-e205-11ea-80bd-765ac1aa4f76.png)

![image](https://user-images.githubusercontent.com/25353789/90668568-23b50080-e205-11ea-982b-b53c6963e6c8.png)

Details about the above figure:

Image size: 25 x 25
gx = 10
gy = 12
N = 5 (for the first example)
N = 2 (for the second example)
(delta) stride = 3

To calculate the NxN filter locations: We can use Equations 19 and 20 from the paper.

In your code it's:
```
# Equation 19.
mu_x = gx + (grid_i - N / 2 - 0.5) * delta
# Equation 20.
mu_y = gy + (grid_i - N / 2 - 0.5) * delta
```

To draw the rectangle, we need the top-left and bottom-right filter locations.
We can simple set the starting and ending grid_i values as so:

With the current `arange`, we would set `grid_i = 0` and `grid_i = N-1`
With the proposed `arange`, we would set `grid_i = 1` and `grid_i = N`